### PR TITLE
Import Command is using X input for Y coordinates

### DIFF
--- a/src/main/java/ivorius/reccomplex/commands/CommandImportStructure.java
+++ b/src/main/java/ivorius/reccomplex/commands/CommandImportStructure.java
@@ -68,7 +68,7 @@ public class CommandImportStructure extends CommandBase
         if (args.length >= 4)
         {
             x = MathHelper.floor_double(func_110666_a(commandSender, (double) x, args[1]));
-            y = MathHelper.floor_double(func_110666_a(commandSender, (double) x, args[2]));
+            y = MathHelper.floor_double(func_110666_a(commandSender, (double) y, args[2]));
             z = MathHelper.floor_double(func_110666_a(commandSender, (double) z, args[3]));
         }
 


### PR DESCRIPTION
This explains why /#import ~ ~-1 ~ is putting my build in the sky. :-)