### PR TITLE
Added an event firing

### DIFF
--- a/src/main/java/ivorius/reccomplex/worldgen/StructureGenerator.java
+++ b/src/main/java/ivorius/reccomplex/worldgen/StructureGenerator.java
@@ -48,6 +48,10 @@ public class StructureGenerator
         StructureSpawnContext structureSpawnContext = new StructureSpawnContext(world, random, structureBoundingBox, generationBB, layer, false, transform, firstTime);
         structureInfo.generate(structureSpawnContext, instanceData);
 
+        int[] size = StructureInfos.structureSize(structureInfo, transform);
+        int[] coordInts = new int[]{coord.x, coord.y, coord.z};
+        MinecraftForge.EVENT_BUS.post(new StructureGenerationEventLite.Post(world, structureName, coordInts, size, layer));
+        
         if (firstTime)
             RecurrentComplex.logger.trace(String.format("Generated structure '%s' in %s", name(structureName), structureSpawnContext.boundingBox));
     }


### PR DESCRIPTION
Made a StructureGenerationEventList.Post be fired when parts are added
to villages or mazes.

This is mainly added so that pokecube can edit pokemart seller AI, and add special sub-biomes to structures in villages, for specific pokemon spawning in specific buildings.