### PR TITLE
Fix block/item missing while generating structures

### DIFF
--- a/src/main/java/ivorius/reccomplex/RCRegistryHandler.java
+++ b/src/main/java/ivorius/reccomplex/RCRegistryHandler.java
@@ -87,54 +87,65 @@ public class RCRegistryHandler
         blockSelector = new ItemBlockSelectorBlock().setUnlocalizedName("blockSelector").setTextureName(textureBase + "blockSelector");
         blockSelector.setCreativeTab(tabStructureTools);
         register(blockSelector, "block_selector");
+        registerFallback(blockSelector, "blockSelector");
         RecurrentComplex.remapper.registerLegacyIDs(blockSelector, "blockSelector");
 
         blockSelectorFloating = new ItemBlockSelectorFloating().setUnlocalizedName("blockSelectorFloating").setTextureName(textureBase + "blockSelectorFloating");
         blockSelectorFloating.setCreativeTab(tabStructureTools);
         register(blockSelectorFloating, "block_selector_floating");
+        registerFallback(blockSelectorFloating, "blockSelectorFloating");
         RecurrentComplex.remapper.registerLegacyIDs(blockSelectorFloating, "blockSelectorFloating");
 
         inventoryGenerationTag = (ItemInventoryGenMultiTag) new ItemInventoryGenMultiTag().setUnlocalizedName("inventoryGenerationTag").setTextureName(textureBase + "inventoryGenerationTag");
         inventoryGenerationTag.setCreativeTab(tabInventoryGenerators);
         register(inventoryGenerationTag, "inventory_generation_tag");
+        registerFallback(inventoryGenerationTag, "inventoryGenerationTag");
         RecurrentComplex.remapper.registerLegacyIDs(inventoryGenerationTag, "inventoryGenerationTag");
 
         inventoryGenerationSingleTag = (ItemInventoryGenSingleTag) new ItemInventoryGenSingleTag().setUnlocalizedName("inventoryGenerationSingleTag").setTextureName(textureBase + "inventoryGenerationSingleTag");
         inventoryGenerationSingleTag.setCreativeTab(tabInventoryGenerators);
         register(inventoryGenerationSingleTag, "inventory_generation_single_tag");
+        registerFallback(inventoryGenerationSingleTag, "inventoryGenerationSingleTag");
         RecurrentComplex.remapper.registerLegacyIDs(inventoryGenerationSingleTag, "inventoryGenerationSingleTag");
 
         inventoryGenerationComponentTag = (ItemInventoryGenComponentTag) new ItemInventoryGenComponentTag().setUnlocalizedName("inventoryGenerationComponentTag").setTextureName(textureBase + "inventoryGenerationComponentTag");
         inventoryGenerationComponentTag.setCreativeTab(tabInventoryGenerators);
         register(inventoryGenerationComponentTag, "inventory_generation_component_tag");
+        registerFallback(inventoryGenerationComponentTag, "inventoryGenerationComponentTag");
 
         artifactGenerationTag = new ItemArtifactGenerator().setUnlocalizedName("artifactGenerationTag").setTextureName(textureBase + "artifactGenerationTag");
         artifactGenerationTag.setCreativeTab(tabInventoryGenerators);
         register(artifactGenerationTag, "artifact_generation_tag");
+        registerFallback(artifactGenerationTag, "artifactGenerationTag");
         RecurrentComplex.remapper.registerLegacyIDs(artifactGenerationTag, "artifactGenerationTag");
 
         bookGenerationTag = new ItemBookGenerator().setUnlocalizedName("bookGenerationTag").setTextureName(textureBase + "bookGenerationTag");
         bookGenerationTag.setCreativeTab(tabInventoryGenerators);
         register(bookGenerationTag, "book_generation_tag");
+        registerFallback(bookGenerationTag, "bookGenerationTag");
         RecurrentComplex.remapper.registerLegacyIDs(bookGenerationTag, "bookGenerationTag");
 
         genericSpace = new BlockGenericSpace().setBlockName("negativeSpace").setBlockTextureName(textureBase + "negativeSpace");
         genericSpace.setCreativeTab(tabStructureTools);
         register(genericSpace, ItemBlockNegativeSpace.class, "generic_space");
+        registerFallback(genericSpace, ItemBlockNegativeSpace.class, "negativeSpace");
         RecurrentComplex.remapper.registerLegacyIDs(genericSpace, true, "negativeSpace");
 
         genericSolid = new BlockGenericSolid().setBlockName("naturalFloor").setBlockTextureName(textureBase + "naturalFloor");
         genericSolid.setCreativeTab(tabStructureTools);
         register(genericSolid, ItemBlockGenericSolid.class, "generic_solid");
+        registerFallback(genericSolid, ItemBlockGenericSolid.class, "naturalFloor");
         RecurrentComplex.remapper.registerLegacyIDs(genericSolid, true, "naturalFloor");
 
         structureGenerator = new BlockStructureGenerator().setBlockName("structureGenerator").setBlockTextureName(textureBase + "structureGenerator");
         register(structureGenerator, "structure_generator");
+        registerFallback(structureGenerator, "structureGenerator");
         register(TileEntityStructureGenerator.class, "RCStructureGenerator", "SGStructureGenerator");
         RecurrentComplex.remapper.registerLegacyIDs(structureGenerator, true, "structureGenerator");
 
         mazeGenerator = new BlockMazeGenerator().setBlockName("mazeGenerator").setBlockTextureName(textureBase + "mazeGenerator");
         register(mazeGenerator, "maze_generator");
+        registerFallback(mazeGenerator, "mazeGenerator");
         register(TileEntityMazeGenerator.class, "RCMazeGenerator", "SGMazeGenerator");
         RecurrentComplex.remapper.registerLegacyIDs(mazeGenerator, true, "mazeGenerator");
 
@@ -152,6 +163,24 @@ public class RCRegistryHandler
         registerDimensionPresets();
         registerBiomePresets();
         registerBlockStatePresets();
+    }
+
+    public static void registerFallback(Item item, String id)
+    {
+        MCRegistrySpecial.INSTANCE.registerFallback(FMLUtils.addPrefix(id), item);
+    }
+
+    public static void registerFallback(Block block, String id)
+    {
+        MCRegistrySpecial.INSTANCE.registerFallback(FMLUtils.addPrefix(id), block);
+        MCRegistrySpecial.INSTANCE.registerFallback(FMLUtils.addPrefix(id), new ItemBlock(block));
+    }
+
+    public static void registerFallback(Block block, Class<? extends ItemBlock> itemClass, String id, Object... itemArgs)
+    {
+        MCRegistrySpecial.INSTANCE.registerFallback(FMLUtils.addPrefix(id), block);
+        Item item = FMLUtils.constructItem(block, itemClass, itemArgs);
+        if (item != null) MCRegistrySpecial.INSTANCE.registerFallback(FMLUtils.addPrefix(id), item);
     }
 
     public static void register(Item item, String id)

--- a/src/main/java/ivorius/reccomplex/structures/MCRegistrySpecial.java
+++ b/src/main/java/ivorius/reccomplex/structures/MCRegistrySpecial.java
@@ -33,6 +33,8 @@ public class MCRegistrySpecial implements MCRegistry
 
     private final BiMap<String, Item> itemMap = HashBiMap.create();
     private final BiMap<String, Block> blockMap = HashBiMap.create();
+    private final BiMap<String, Item> itemMapFallback = HashBiMap.create();
+    private final BiMap<String, Block> blockMapFallback = HashBiMap.create();
     private final Map<String, Class<? extends TileEntity>> tileEntityMap = new HashMap<>();
 
     private ItemHidingRegistry itemHidingRegistry = new ItemHidingRegistry(this);
@@ -45,6 +47,16 @@ public class MCRegistrySpecial implements MCRegistry
     public void register(String id, Block block)
     {
         blockMap.put(id, block);
+    }
+
+    public void registerFallback(String id, Item item)
+    {
+        itemMapFallback.put(id, item);
+    }
+
+    public void registerFallback(String id, Block block)
+    {
+        blockMapFallback.put(id, block);
     }
 
     public void register(String id, Class<? extends TileEntity> tileEntity)
@@ -61,6 +73,7 @@ public class MCRegistrySpecial implements MCRegistry
     public Item itemFromID(String itemID)
     {
         Item item = itemMap.get(itemID);
+        if (item == null) item = itemMapFallback.get(itemID);
         return item != null ? item : (Item) Item.itemRegistry.getObject(itemID);
     }
 
@@ -86,6 +99,7 @@ public class MCRegistrySpecial implements MCRegistry
     public Block blockFromID(String blockID)
     {
         Block block = blockMap.get(blockID);
+        if (block == null) block = blockMapFallback.get(blockID);
         return block != null ? block : Block.getBlockFromName(blockID);
     }
 
@@ -142,6 +156,7 @@ public class MCRegistrySpecial implements MCRegistry
         public Item itemFromID(String itemID)
         {
             Item item = parent.itemMap.get(itemID);
+            if (item == null) item = parent.itemMapFallback.get(itemID);
             return item != null ? Items.coal : (Item) Item.itemRegistry.getObject(itemID);
         }
 
@@ -192,6 +207,13 @@ public class MCRegistrySpecial implements MCRegistry
         public void modifyItemStackCompound(NBTTagCompound compound, String itemID)
         {
             Item item = parent.itemMap.get(itemID);
+            if (item == null) {
+                item = parent.itemMapFallback.get(itemID);
+                if (item != null) {
+                    String _itemID = parent.idFromItem(item);
+                    if (_itemID != null) itemID = _itemID;
+                }
+            }
             if (item != null)
             {
                 NBTTagCompound stackNBT;


### PR DESCRIPTION
## Issue:
Before this commit:
![before](http://i.imgur.com/qPgqzM3.png)
And in logs:
> [01:21:19] [Server thread/WARN] [ivtoolkit]: Failed to fix item tag from structure with ID 'reccomplex:inventoryGenerationTag'

After this commit:
![after](http://i.imgur.com/MHyMi8p.png)

## How to reproduce:
forge1448 + RecurrentComplex-0.9.6.3.n320 + IvToolkit-1.2.1.n85, create a new world and find its natural generated structures(or use /#gen command).

## Why
In [this commit](https://github.com/Ivorforce/RecurrentComplex/commit/664b3fa43e8eddf39cac8ceeb8422dc67e4e4679) you have changed some block ids and item ids while those structures in the assets were still using old ids.