### PR TITLE
Makes search in Tweaks GUI case-insensitive

### DIFF
--- a/src/main/java/ivorius/reccomplex/gui/tweak/TableDataSourceTweakStructuresList.java
+++ b/src/main/java/ivorius/reccomplex/gui/tweak/TableDataSourceTweakStructuresList.java
@@ -61,7 +61,7 @@ public class TableDataSourceTweakStructuresList extends TableDataSourceSegmented
         editingIDs.addAll(StructureRegistry.INSTANCE.ids());
 
         if (search != null) {
-            editingIDs.removeIf(id -> !id.contains(search));
+            editingIDs.removeIf(id.toLowerCase() -> !id.toLowerCase.contains(search.toLowerCase()));
         }
 
         editingIDs.sort(String::compareTo);

--- a/src/main/java/ivorius/reccomplex/gui/tweak/TableDataSourceTweakStructuresList.java
+++ b/src/main/java/ivorius/reccomplex/gui/tweak/TableDataSourceTweakStructuresList.java
@@ -61,7 +61,7 @@ public class TableDataSourceTweakStructuresList extends TableDataSourceSegmented
         editingIDs.addAll(StructureRegistry.INSTANCE.ids());
 
         if (search != null) {
-            editingIDs.removeIf(id -> !id.toLowerCase.contains(search.toLowerCase()));
+            editingIDs.removeIf(id -> !id.toLowerCase().contains(search.toLowerCase()));
         }
 
         editingIDs.sort(String::compareTo);

--- a/src/main/java/ivorius/reccomplex/gui/tweak/TableDataSourceTweakStructuresList.java
+++ b/src/main/java/ivorius/reccomplex/gui/tweak/TableDataSourceTweakStructuresList.java
@@ -61,7 +61,7 @@ public class TableDataSourceTweakStructuresList extends TableDataSourceSegmented
         editingIDs.addAll(StructureRegistry.INSTANCE.ids());
 
         if (search != null) {
-            editingIDs.removeIf(id.toLowerCase() -> !id.toLowerCase.contains(search.toLowerCase()));
+            editingIDs.removeIf(id -> !id.toLowerCase.contains(search.toLowerCase()));
         }
 
         editingIDs.sort(String::compareTo);


### PR DESCRIPTION
To be honest, I didn't test this. If the code is somehow wrong, feel free to edit it. 🐢
I was searching for mazes and wondered why I didn't find anything with `maze`.

Oh, and I didn't know where to commit to (`1.12` or `master`) 🤦‍♀️ Sorry!

_//e: And apparently, the build fails. You might aswell just edit this in yourself manually if you want 🙍...
//e²: yay_