### PR TITLE
Fix misconfigured shadow task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ jar {
 shadowJar {
     archiveClassifier = ''
     configurations = [project.configurations.shade]
-    relocate 'ivorius.mcopts', "${project.group}..shadow.mcopts"
+    relocate 'ivorius.mcopts', "${project.group}.shadow.mcopts"
     finalizedBy 'reobfShadowJar'
 }
 


### PR DESCRIPTION
This fixes a `ClassNotFoundException` and subsequent server crash on some JVMs including Temurin 17 and OpenJ9. See #491 